### PR TITLE
remove duplicate item for Germany

### DIFF
--- a/src/stripeTaxMap.ts
+++ b/src/stripeTaxMap.ts
@@ -142,13 +142,6 @@ export default [
     example: "DE123456789",
   },
   {
-    country: "DE",
-    type: "eu_vat",
-    description: "Germany - European VAT number",
-    regex: /^DE[0-9]{9}$/,
-    example: "DE123456789",
-  },
-  {
     country: "GR",
     type: "eu_vat",
     description: "Greece - European VAT number",


### PR DESCRIPTION
Germany is specified twice which prevents people from setting GE tax id (if 2 matches are found, `null` is returned).