### PR TITLE
Correct regex pattern for romanian vat ids

### DIFF
--- a/src/stripeTaxMap.ts
+++ b/src/stripeTaxMap.ts
@@ -351,7 +351,7 @@ export default [
     country: 'RO',
     type: 'eu_vat',
     description: 'Romania - European VAT number',
-    regex: /^RO[0-9]{10}$/,
+    regex: /^RO[0-9]{8,10}$/,
     example: 'RO1234567891',
   },
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -68,4 +68,15 @@ describe('stripe tax utils', () => {
     const type = stripeTax.getTaxItem({ country: 'xxx', taxId: 'GB123456789' });
     expect(type).toBe(null);
   });
+
+  it('Should return when Romanian tax id length is 8 characters', () => {
+    const type = stripeTax.getTaxItem({ country: 'RO', taxId: 'RO12345678'});
+    expect(type).toStrictEqual({
+      country: 'RO',
+      type: 'eu_vat',
+      description: 'Romania - European VAT number',
+      regex: /^RO[0-9]{8,10}$/,
+      example: 'RO1234567891',
+    })
+  });
 });


### PR DESCRIPTION
The pattern used for validating EU VAT ids from Romania are incorrect. The length of an id can vary between 8 to 10 characters. This needs to be corrected.