### PR TITLE
fix: switzerland VAT regex fix

### DIFF
--- a/src/stripeTaxMap.ts
+++ b/src/stripeTaxMap.ts
@@ -508,10 +508,8 @@ export default [
     country: 'CH',
     type: 'ch_vat',
     description: 'Switzerland - European VAT number',
-    //regex: /^CHE-[0-9]{3}\.[0-9]{3}\.[0-9]{3}(\s)?MWST$/,
-    //example: 'CHE-123.456.789 MWST',
-    regex: /^CHE[0-9]{9}(\s)(MWST|TVA|IVA)$/, // "CHE"+9 digits and the letters "TVA/MWST/IVA", which indicates VAT registration, e.g. CHE123456789 MWST.
-    example: 'CHE123456789 MWST',
+    regex: /^CHE-[0-9]{3}.[0-9]{3}.[0-9]{3}(\s)(MWST|TVA|IVA)$/,
+    example: 'CHE-123.456.789 MWST',
   },
   {
     country: 'TW',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -107,4 +107,13 @@ describe('stripe tax utils', () => {
       );
     }
   });
+
+  it('Should accept valid Switzerland tax id', () => {
+    const ids = ['CHE-123.456.789 MWST'];
+    for (const id of ids) {
+      expect(stripeTax.getTaxItem({ country: 'CH', taxId: id })).toEqual(
+        expect.objectContaining({ type: 'ch_vat', country: 'CH' })
+      );
+    }
+  });
 });


### PR DESCRIPTION
This matches what the stripe documentation says (https://docs.stripe.com/billing/customer/tax-ids) and what I see from our customers.

```
Switzerland	ch_vat	Switzerland VAT number	CHE-123.456.789 MWST
```