### PR TITLE
fix: mexico regex

### DIFF
--- a/src/stripeTaxMap.ts
+++ b/src/stripeTaxMap.ts
@@ -378,7 +378,8 @@ export default [
     country: 'MX',
     type: 'mx_rfc',
     description: 'Mexican RFC number',
-    regex: /^[A-Z]{3}[0-9]{6}[A-Z]{2}[0-9]{1}$/,
+    // https://learn.sayari.com/mexico-tax-id-number-rfc/
+    regex: /^[A-Z]{4}[0-9]{6}[A-Z0-9]{3}$/,
     example: 'ABC010203AB9',
   },
 


### PR DESCRIPTION
MX has 13-char string (instead of 12 for previous regex), and the last 3 char checksum can be fully alphanumeric.

https://learn.sayari.com/mexico-tax-id-number-rfc/