### PR TITLE
Update the regex for Chilean TIN, last section

### DIFF
--- a/src/stripeTaxMap.ts
+++ b/src/stripeTaxMap.ts
@@ -122,7 +122,7 @@ export default [
     country: 'CL',
     type: 'cl_tin',
     description: 'Chilean TIN',
-    regex: /^[0-9]{2}\.[0-9]{3}\.[0-9]{3}-K$/,
+    regex: /^[0-9]{2}\.[0-9]{3}\.[0-9]{3}-[0-9K]$/,
     example: '12.345.678-K',
   },
   {


### PR DESCRIPTION
is one digit ranging from 0 to 9 or letter K.

https://www.oecd.org/content/dam/oecd/en/topics/policy-issue-focus/aeoi/chile-tin.pdf